### PR TITLE
More API methods

### DIFF
--- a/lib/cardinity.rb
+++ b/lib/cardinity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cardinity/version'
 require 'cardinity/utils'
 require 'cardinity/auth'
@@ -67,9 +69,17 @@ module Cardinity
     parse patch(payment_uri(payment_id), serialize(authorize_hash))
   end
 
-  # Get list of all payments
-  def self.payments
-    parse get(payments_uri)
+  # Get list of the last payments.
+  # By default, cardinity returns 10 payments. Pass `limit` to override.
+  def self.payments(limit: nil)
+    query = {}
+    query[:limit] = limit if limit
+    parse get(payments_uri, query)
+  end
+
+  # Get the payment information for the given payment ID.
+  def self.payment(payment_id)
+    parse get(payment_uri(payment_id))
   end
 
 end

--- a/lib/cardinity.rb
+++ b/lib/cardinity.rb
@@ -20,9 +20,15 @@ module Cardinity
   TYPE_PURCHASE = 'purchase'
   TYPE_ERROR = 'https://developers.cardinity.com/api/v1/'
 
+  # Configure Cardinity. Must be called before other methods.
+  #
+  # @param [Hash] options
+  # @option options [String] :key API key.
+  # @option options [String] :secret API secret.
+  # @option options [String] :api_base (DEFAULT_API_BASE) API base URL.
   def self.configure!(options)
     @config = {
-        # key and secret to be supplied from outsite
+        # key and secret to be supplied from outside
         api_base: DEFAULT_API_BASE
     }
     @config.merge! options
@@ -31,24 +37,25 @@ module Cardinity
 
   # Creates a Payment object
   #
-  # Accepted attributes:
-  # - amount (#0.00, two decimals required)
-  # - currency (EUR,USD)
-  # - settle (boolean, default true, false means just pre-authorize and finish later)
-  # - order_id (not required)
-  # - description (not required)
-  # - country (country of customer, required)
-  # - payment_method (required, only supported value is card)
-  # - payment_instrument (card details)
-  #   - pan (card number)
-  #   - exp_year
-  #   - exp_month
-  #   - cvc
-  #   - holder
-  #
-  # Returns:
-  # - updated payment object on success
-  # - error object on error
+  # @param [Hash] payment_hash Payment data. Keys can be symbols or strings.
+  # @option payment_hash [Numeric, String] :amount #0.00.
+  #   If a string, two decimals are required.
+  # @option payment_hash [String] :currency Three-letter ISO currency code,
+  #   e.g. "EUR".
+  # @option payment_hash [Boolean] :settle (true) If false, creates a
+  #   pre-authorization instead of settling immediately.
+  # @option payment_hash [String] :country Customer's billing country as
+  #   ISO 3166-1 alpha-2 country code, required.
+  # @option payment_hash [String] :payment_method ('card')
+  # @option payment_hash [Hash] :payment_instrument Card details:
+  #   * :pan [String] Card number.
+  #   * :exp_year [Integer] 4-digit year.
+  #   * :exp_month [Integer] 2-digit month
+  #   * :cvc [Integer] Card security code.
+  #   * :holder [String] Cardholder's name, max length 32 characters.
+  # @option payment_hash [String, nil] :order_id (nil)
+  # @option payment_hash [String, nil] :description (nil)
+  # @return [Hash] Updated payment object or an error object.
   def self.create_payment(payment_hash)
     checked_payment_data = check_payment_data(payment_hash)
     parse post(payments_uri, serialize(checked_payment_data))
@@ -59,18 +66,17 @@ module Cardinity
   # This is necessary for 3D secure payments, when the customer has completed
   # the 3D secure redirects and authorization.
   #
-  # Accepted attributes:
-  #  - authorize_data (PaRes string received from 3D secure)
-  #
-  # Returns:
-  # - updated payment object on success
-  # - error object on error
+  # @param [String] payment_id
+  # @param [String] authorize_data PaRes string received from 3D secure.
+  # @return [Hash] Payment or error object.
   def self.finalize_payment(payment_id, authorize_hash)
     parse patch(payment_uri(payment_id), serialize(authorize_hash))
   end
 
   # Get list of the last payments.
   # By default, cardinity returns 10 payments. Pass `limit` to override.
+  # @param [Integer, nil] limit
+  # @return [Array<Hash>, Hash] Payment objects or an error object.
   def self.payments(limit: nil)
     query = {}
     query[:limit] = limit if limit
@@ -78,16 +84,34 @@ module Cardinity
   end
 
   # Get the payment information for the given payment ID.
+  # @param [String] payment_id
+  # @return [Hash] Payment or error object.
   def self.payment(payment_id)
     parse get(payment_uri(payment_id))
   end
 
+  # Fully or partially refund a payment
+  # @param [String] payment_id
+  # @param [Numeric, String] amount If a string, two decimals are required.
+  # @param [String] description
+  # @return [Hash] Refund or error object.
+  def self.create_refund(payment_id, amount:, description: '')
+    amount = format('%.2f', amount) if amount.is_a?(Numeric)
+    parse post(refunds_uri(payment_id),
+               serialize(amount: amount, description: description))
+  end
+
   # Get all the refunds for the given payment ID.
+  # @param [String] payment_id
+  # @return [Array<Hash>, Hash] Refund objects or an error object.
   def self.refunds(payment_id)
     parse get(refunds_uri(payment_id))
   end
 
   # Get the refund for the given payment ID and refund ID.
+  # @param [String] payment_id
+  # @param [String] refund_id
+  # @return [Hash] Refund or error object.
   def self.refund(payment_id, refund_id)
     parse get(refund_uri(payment_id, refund_id))
   end

--- a/lib/cardinity.rb
+++ b/lib/cardinity.rb
@@ -82,4 +82,13 @@ module Cardinity
     parse get(payment_uri(payment_id))
   end
 
+  # Get all the refunds for the given payment ID.
+  def self.refunds(payment_id)
+    parse get(refunds_uri(payment_id))
+  end
+
+  # Get the refund for the given payment ID and refund ID.
+  def self.refund(payment_id, refund_id)
+    parse get(refund_uri(payment_id, refund_id))
+  end
 end

--- a/lib/cardinity/auth.rb
+++ b/lib/cardinity/auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'openssl'
 require 'uri'
@@ -12,16 +14,16 @@ class Cardinity::Auth
     @config = config
   end
 
-  def sign_request(method, uri)
+  def sign_request(method, uri, params = {})
     params = {
         oauth_consumer_key: @config[:key],
         oauth_nonce: generate_key,
         oauth_signature_method: SIGNATURE_METHOD,
         oauth_timestamp: generate_timestamp,
         oauth_version: OAUTH_VERSION
-    }
+    }.update(params)
     params[:oauth_signature] = request_signature(method, uri, params)
-    params_str = params.collect { |k, v| "#{k}=\"#{escape(v)}\"" }.join(', ')
+    params_str = params.map { |k, v| "#{k}=\"#{escape(v.to_s)}\"" }.join(', ')
     "OAuth #{params_str}"
   end
 

--- a/lib/cardinity/utils.rb
+++ b/lib/cardinity/utils.rb
@@ -28,6 +28,14 @@ module Cardinity
     "#{api_base}#{API_PAYMENTS}/#{payment_id}"
   end
 
+  def self.refunds_uri(payment_id)
+    "#{api_base}#{API_PAYMENTS}/#{payment_id}/refunds"
+  end
+
+  def self.refund_uri(payment_id, refund_id)
+    "#{api_base}#{API_PAYMENTS}/#{payment_id}/refunds/#{refund_id}"
+  end
+
   def self.parse(response)
     JSON.parse response.body
   end

--- a/lib/cardinity/utils.rb
+++ b/lib/cardinity/utils.rb
@@ -1,14 +1,21 @@
+# frozen_string_literal: true
+
+require 'uri'
+
 module Cardinity
 
-  CODES_WITH_RESPONSE = [200, 201, 202, 400, 402]
+  CODES_WITH_RESPONSE = [200, 201, 202, 400, 401, 402, 405, 500, 503]
 
   def self.check_payment_data(payment)
     payment = payment.dup
-    if payment[:payment_method].nil?
-      payment[:payment_method] = 'card'
+    payment_method = payment['payment_method'] || payment[:payment_method]
+    if payment_method.nil?
+      payment['payment_method'] = 'card'
     end
-    if payment[:amount].is_a?(Numeric)
-      payment[:amount] = '%.2f' % payment[:amount]
+    amount = payment['amount'] || payment[:amount]
+    if amount.is_a?(Numeric)
+      payment.delete(:amount)
+      payment['amount'] = format('%.2f', amount)
     end
     payment
   end
@@ -37,8 +44,10 @@ module Cardinity
     end
   end
 
-  def self.get(uri)
-    RestClient.get uri, headers(:get, uri)
+  def self.get(base_url, params = {})
+    uri = URI.parse(base_url)
+    uri.query = URI.encode_www_form(params)
+    RestClient.get uri.to_s, headers(:get, base_url, params)
   rescue RestClient::ExceptionWithResponse => e
     handle_error_response e
   end
@@ -55,10 +64,10 @@ module Cardinity
     handle_error_response e
   end
 
-  def self.headers(method, uri)
+  def self.headers(method, uri, params = {})
     {
         content_type: 'application/json',
-        authorization: @auth.sign_request(method, uri)
+        authorization: @auth.sign_request(method, uri, params)
     }
   end
 

--- a/lib/cardinity/version.rb
+++ b/lib/cardinity/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cardinity
   VERSION = "0.1.1"
 end

--- a/test/auth_test.rb
+++ b/test/auth_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class AuthTest < Minitest::Test

--- a/test/cardinity_test.rb
+++ b/test/cardinity_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CardinityTest < Minitest::Test

--- a/test/cardinity_test.rb
+++ b/test/cardinity_test.rb
@@ -32,6 +32,22 @@ class CardinityTest < Minitest::Test
     assert Cardinity.payments.is_a?(Array)
   end
 
+  def test_fetch_payment
+    payment_id = Cardinity.create_payment(@payment_data)['id']
+    assert_equal Cardinity.payment(payment_id)['id'], payment_id
+  end
+
+  def test_refund
+    payment_id = Cardinity.create_payment(@payment_data)['id']
+    create_refund_response = Cardinity.create_refund(
+      payment_id, amount: @payment_data[:amount], description: 'test refund'
+    )
+    assert_equal create_refund_response['description'], 'test refund'
+    refund_id = create_refund_response['id']
+    assert_equal Cardinity.refund(payment_id, refund_id)['id'], refund_id
+    assert_equal Cardinity.refunds(payment_id)[0]['id'], refund_id
+  end
+
   VISA_1 = "4111111111111111"
 
   VISA_2 = "4222222222222"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'cardinity'
 


### PR DESCRIPTION
1. Adds the `limit` argument to `payments`.
2. Adds the `payment` API method.
3. Adds `create_refund`, `refund`, and `refunds`.
4. Adds string key support to `check_payment_data`.
5. Adds missing `CODES_WITH_RESPONSE` as per Cardinity documentation.
6. Documents all public method types with YARD.